### PR TITLE
Feat: 1271

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,40 +1,23 @@
-name: CI
+name: Tests
 
 on:
   push:
   pull_request:
   workflow_dispatch:
 
-env:
-  FOUNDRY_PROFILE: ci
-
 jobs:
   check:
-    name: Foundry project
+    name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - name: Install
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
 
-      - name: version
-        run: |
-          forge --version
-
-      - name: fmt
-        run: |
-          forge fmt --check
-        id: fmt
-
-      - name: Build
-        run: |
-          forge build --sizes
-        id: build
-
-      - name: Test
-        run: |
-          forge test -vvv
-        id: test
+      - name: Run tests
+        run: forge test -vvv

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,20 +1,40 @@
-on: [push]
+name: CI
 
-name: test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
 
 jobs:
   check:
-    name: Tests
+    name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install Foundry
+      - name: Install
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
-      - name: Run tests
-        run: forge test -vvv
+      - name: version
+        run: |
+          forge --version
+
+      - name: fmt
+        run: |
+          forge fmt --check
+        id: fmt
+
+      - name: Build
+        run: |
+          forge build --sizes
+        id: build
+
+      - name: Test
+        run: |
+          forge test -vvv
+        id: test

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,9 +1,6 @@
 name: Tests
 
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
+on: [push]
 
 jobs:
   check:

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "lib/solenv"]
 	path = lib/solenv
 	url = https://github.com/memester-xyz/solenv
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/vectorized/solady

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,17 @@
+{
+  "lib/forge-std": {
+    "rev": "d26946aeef956d9d11238ce02c94b7a22ac23ca8"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "8769b19860863ed14e82ac78eb0d09449a49290b"
+  },
+  "lib/solady": {
+    "tag": {
+      "name": "v0.1.26",
+      "rev": "acd959aa4bd04720d640bf4e6a5c71037510cc4b"
+    }
+  },
+  "lib/solmate": {
+    "rev": "bff24e835192470ed38bf15dbed6084c2d723ace"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,5 +14,6 @@ runs = 10_000
 [fmt]
 line_length = 120
 tab_width = 4
+bracket_spacing = true
 wrap_comments = true
 single_line_statement_blocks = "single"

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,5 +14,5 @@ runs = 10_000
 [fmt]
 line_length = 120
 tab_width = 4
-bracket_spacing = true
+wrap_comments = true
 single_line_statement_blocks = "single"

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,6 +2,7 @@ openzeppelin/=lib/openzeppelin-contracts/contracts/
 openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
 
 solmate/=lib/solmate/src/
+solady/=lib/solady/src/
 
 common/=src/common/
 creator/=src/creator/

--- a/src/dev/mocks/ERC1271Mock.sol
+++ b/src/dev/mocks/ERC1271Mock.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { ECDSA } from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+
+contract ERC1271Mock {
+    address public signer;
+
+    bytes4 internal constant MAGIC_VALUE_1271 = 0x1626ba7e;
+
+    constructor(address _signer) {
+        signer = _signer;
+    }
+
+    function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4) {
+        return ECDSA.recover(hash, signature) == signer ? MAGIC_VALUE_1271 : bytes4(0);
+    }
+}

--- a/src/exchange/libraries/OrderStructs.sol
+++ b/src/exchange/libraries/OrderStructs.sol
@@ -36,27 +36,26 @@ struct Order {
     bytes signature;
 }
 
-enum SignatureType
-// 0: ECDSA EIP712 signatures signed by EOAs
-{
+enum SignatureType {
+    // 0: ECDSA EIP712 signatures signed by EOAs
     EOA,
     // 1: EIP712 signatures signed by EOAs that own Polymarket Proxy wallets
     POLY_PROXY,
     // 2: EIP712 signatures signed by EOAs that own Polymarket Gnosis safes
-    POLY_GNOSIS_SAFE
+    POLY_GNOSIS_SAFE,
+    // 3: EIP1271 signatures signed by smart contracts. To be used by smart contract wallets or vaults
+    POLY_1271
 }
 
-enum Side
-// 0: buy
-{
+enum Side {
+    // 0: buy
     BUY,
     // 1: sell
     SELL
 }
 
-enum MatchType
-// 0: buy vs sell
-{
+enum MatchType {
+    // 0: buy vs sell
     COMPLEMENTARY,
     // 1: both buys
     MINT,

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -29,6 +29,7 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
     /// @param associated       - Address associated with the signer.
     ///                           For signature type EOA, this MUST be the same as the signer address.
     ///                           For signature types POLY_PROXY and POLY_GNOSIS_SAFE, this is the address of the proxy or the safe
+    //                            For signature type POLY_1271, this is the address of the contract address
     /// @param structHash       - The hash of the struct being verified
     /// @param signature        - The signature to be verified
     /// @param signatureType    - The signature type to be verified
@@ -40,10 +41,13 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
         SignatureType signatureType
     ) internal view returns (bool) {
         if (signatureType == SignatureType.EOA) {
+            // EOA
             return verifyEOASignature(signer, associated, structHash, signature);
         } else if (signatureType == SignatureType.POLY_GNOSIS_SAFE) {
+            // POLY_GNOSIS_SAFE
             return verifyPolySafeSignature(signer, associated, structHash, signature);
         } else if (signatureType == SignatureType.POLY_1271) {
+            // POLY_1271
             return verifyPoly1271Signature(signer, structHash, signature);
         } else {
             // POLY_PROXY
@@ -116,13 +120,17 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
     /// @param contractAddress  - Address of the smart contract
     /// @param hash             - Hash of the struct being verified
     /// @param signature        - Signature to be verified
-    function verifyPoly1271Signature(address contractAddress, bytes32 hash, bytes memory signature) internal view returns (bool) {
-        (bool success, bytes memory result) = contractAddress.staticcall(
-            abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature)
-        );
+    function verifyPoly1271Signature(address contractAddress, bytes32 hash, bytes memory signature)
+        internal
+        view
+        returns (bool)
+    {
+        (bool success, bytes memory result) =
+            contractAddress.staticcall(abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature));
 
-        return (success &&
-            result.length >= 32 &&
-            abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector));
+        return (
+            success && result.length >= 32
+                && abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector)
+        );
     }
 }

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -28,7 +28,8 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
     /// @param signer           - Address of the signer
     /// @param associated       - Address associated with the signer.
     ///                           For signature type EOA, this MUST be the same as the signer address.
-    ///                           For signature types POLY_PROXY and POLY_GNOSIS_SAFE, this is the address of the proxy or the safe
+    ///                           For signature types POLY_PROXY and POLY_GNOSIS_SAFE, this is the address of the proxy
+    ///                           or the safe
     //                            For signature type POLY_1271, this is the address of the contract address
     /// @param structHash       - The hash of the struct being verified
     /// @param signature        - The signature to be verified

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -43,6 +43,8 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
             return verifyEOASignature(signer, associated, structHash, signature);
         } else if (signatureType == SignatureType.POLY_GNOSIS_SAFE) {
             return verifyPolySafeSignature(signer, associated, structHash, signature);
+        } else if (signatureType == SignatureType.POLY_1271) {
+            return verifyPoly1271Signature(signer, structHash, signature);
         } else {
             // POLY_PROXY
             return verifyPolyProxySignature(signer, associated, structHash, signature);
@@ -108,5 +110,19 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
         returns (bool)
     {
         return verifyECDSASignature(signer, hash, signature) && getSafeAddress(signer) == safeAddress;
+    }
+
+    /// @notice Verifies a signature signed by a smart contract
+    /// @param contractAddress  - Address of the smart contract
+    /// @param hash             - Hash of the struct being verified
+    /// @param signature        - Signature to be verified
+    function verifyPoly1271Signature(address contractAddress, bytes32 hash, bytes memory signature) internal view returns (bool) {
+        (bool success, bytes memory result) = contractAddress.staticcall(
+            abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature)
+        );
+
+        return (success &&
+            result.length >= 32 &&
+            abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector));
     }
 }

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -49,7 +49,7 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
             return verifyPolySafeSignature(signer, associated, structHash, signature);
         } else if (signatureType == SignatureType.POLY_1271) {
             // POLY_1271
-            return verifyPoly1271Signature(signer, structHash, signature);
+            return verifyPoly1271Signature(associated, structHash, signature);
         } else {
             // POLY_PROXY
             return verifyPolyProxySignature(signer, associated, structHash, signature);
@@ -118,7 +118,7 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
     }
 
     /// @notice Verifies a signature signed by a smart contract
-    /// @param contractAddress  - Address of the smart contract
+    /// @param contractAddress  - Address of the 1271 smart contract
     /// @param hash             - Hash of the struct being verified
     /// @param signature        - Signature to be verified
     function verifyPoly1271Signature(address contractAddress, bytes32 hash, bytes memory signature)

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -49,7 +49,7 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
             return verifyPolySafeSignature(signer, associated, structHash, signature);
         } else if (signatureType == SignatureType.POLY_1271) {
             // POLY_1271
-            return verifyPoly1271Signature(associated, structHash, signature);
+            return verifyPoly1271Signature(signer, associated, structHash, signature);
         } else {
             // POLY_PROXY
             return verifyPolyProxySignature(signer, associated, structHash, signature);
@@ -118,15 +118,16 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
     }
 
     /// @notice Verifies a signature signed by a smart contract
-    /// @param contractAddress  - Address of the 1271 smart contract
+    /// @param signer           - Address of the 1271 smart contract
+    /// @param maker            - Address of the 1271 smart contract
     /// @param hash             - Hash of the struct being verified
     /// @param signature        - Signature to be verified
-    function verifyPoly1271Signature(address contractAddress, bytes32 hash, bytes memory signature)
+    function verifyPoly1271Signature(address signer, address maker, bytes32 hash, bytes memory signature)
         internal
         view
         returns (bool)
     {
-        return contractAddress.code.length > 0
-            && SignatureCheckerLib.isValidSignatureNow(contractAddress, hash, signature);
+        return (signer == maker) && maker.code.length > 0
+            && SignatureCheckerLib.isValidSignatureNow(maker, hash, signature);
     }
 }

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -30,7 +30,7 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
     ///                           For signature type EOA, this MUST be the same as the signer address.
     ///                           For signature types POLY_PROXY and POLY_GNOSIS_SAFE, this is the address of the proxy
     ///                           or the safe
-    //                            For signature type POLY_1271, this is the address of the contract address
+    ///                           For signature type POLY_1271, this is the address of the contract
     /// @param structHash       - The hash of the struct being verified
     /// @param signature        - The signature to be verified
     /// @param signatureType    - The signature type to be verified

--- a/src/exchange/mixins/Signatures.sol
+++ b/src/exchange/mixins/Signatures.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
-import { IERC1271 } from "openzeppelin-contracts/interfaces/IERC1271.sol";
+import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 import { ECDSA } from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
 
 import { SignatureType, Order } from "../libraries/OrderStructs.sol";
@@ -126,12 +126,7 @@ abstract contract Signatures is ISignatures, PolyFactoryHelper {
         view
         returns (bool)
     {
-        (bool success, bytes memory result) =
-            contractAddress.staticcall(abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature));
-
-        return (
-            success && result.length >= 32
-                && abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector)
-        );
+        return contractAddress.code.length > 0
+            && SignatureCheckerLib.isValidSignatureNow(contractAddress, hash, signature);
     }
 }

--- a/src/exchange/test/BaseExchangeTest.sol
+++ b/src/exchange/test/BaseExchangeTest.sol
@@ -2,7 +2,10 @@
 pragma solidity <0.9.0;
 
 import { TestHelper } from "dev/TestHelper.sol";
+
 import { USDC } from "dev/mocks/USDC.sol";
+import { ERC1271Mock } from "dev/mocks/ERC1271Mock.sol";
+
 import { Deployer } from "dev/util/Deployer.sol";
 
 import { IERC20 } from "openzeppelin-contracts/token/ERC20/IERC20.sol";
@@ -19,7 +22,7 @@ import { ISignaturesEE } from "exchange/interfaces/ISignatures.sol";
 import { IConditionalTokens } from "exchange/interfaces/IConditionalTokens.sol";
 
 import { CalculatorHelper } from "exchange/libraries/CalculatorHelper.sol";
-import { Order, Side, MatchType, OrderStatus, SignatureType } from "exchange/libraries/OrderStructs.sol";
+import { Order, Side, SignatureType } from "exchange/libraries/OrderStructs.sol";
 
 contract BaseExchangeTest is TestHelper, IAuthEE, IFeesEE, IRegistryEE, IPausableEE, ITradingEE, ISignaturesEE {
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _checkpoints1155;
@@ -38,6 +41,8 @@ contract BaseExchangeTest is TestHelper, IAuthEE, IFeesEE, IRegistryEE, IPausabl
     uint256 internal carlaPK = 0xCA414;
     address public bob;
     address public carla;
+
+    ERC1271Mock public contractWallet;
 
     // ERC20 transfer event
     event Transfer(address indexed from, address indexed to, uint256 value);
@@ -61,6 +66,9 @@ contract BaseExchangeTest is TestHelper, IAuthEE, IFeesEE, IRegistryEE, IPausabl
         conditionId = _prepareCondition(admin, questionID);
         yes = _getPositionId(2);
         no = _getPositionId(1);
+
+        // Deploy a 1271 contract and set carla as the signer
+        contractWallet = new ERC1271Mock(carla);
 
         vm.startPrank(admin);
         exchange = new CTFExchange(address(usdc), address(ctf), address(0), address(0));
@@ -101,6 +109,18 @@ contract BaseExchangeTest is TestHelper, IAuthEE, IFeesEE, IRegistryEE, IPausabl
         address maker = vm.addr(pk);
         Order memory order = _createOrder(maker, tokenId, makerAmount, takerAmount, side);
         order.signature = _signMessage(pk, exchange.hashOrder(order));
+        return order;
+    }
+
+    function _createAndSign1271Order(uint256 signerPk, address wallet, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, Side side) 
+        internal
+        returns (Order memory)
+    {
+        Order memory order = _createOrder(wallet, tokenId, makerAmount, takerAmount, side);
+        order.signer = wallet;
+        order.maker = wallet;
+        order.signatureType = SignatureType.POLY_1271;
+        order.signature = _signMessage(signerPk, exchange.hashOrder(order));
         return order;
     }
 

--- a/src/exchange/test/BaseExchangeTest.sol
+++ b/src/exchange/test/BaseExchangeTest.sol
@@ -117,8 +117,6 @@ contract BaseExchangeTest is TestHelper, IAuthEE, IFeesEE, IRegistryEE, IPausabl
         returns (Order memory)
     {
         Order memory order = _createOrder(wallet, tokenId, makerAmount, takerAmount, side);
-        order.signer = wallet;
-        order.maker = wallet;
         order.signatureType = SignatureType.POLY_1271;
         order.signature = _signMessage(signerPk, exchange.hashOrder(order));
         return order;

--- a/src/exchange/test/ERC1271.t.sol
+++ b/src/exchange/test/ERC1271.t.sol
@@ -1,17 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity <0.9.0;
 
-import { ERC1271Mock } from "dev/mocks/ERC1271Mock.sol";
-
 import { BaseExchangeTest } from "exchange/test/BaseExchangeTest.sol";
 import { Order, Side, SignatureType } from "exchange/libraries/OrderStructs.sol";
 
-contract SignaturesTest is BaseExchangeTest {
-
-    function test_validateOrderSignature() public {
-        Order memory order = _createAndSignOrder(bobPK, yes, 50_000_000, 100_000_000, Side.BUY);
-        exchange.validateOrderSignature(exchange.hashOrder(order), order);
-    }
+contract ERC1271SignatureTest is BaseExchangeTest {
 
     function test_validate1271Signature() public {
         Order memory order =

--- a/src/exchange/test/ERC1271Signature.t.sol
+++ b/src/exchange/test/ERC1271Signature.t.sol
@@ -47,4 +47,15 @@ contract ERC1271SignatureTest is BaseExchangeTest {
         vm.expectRevert(InvalidSignature.selector);
         exchange.validateOrderSignature(orderHash, order);
     }
+
+    function test_validate1271Signature_revert_invalidSignerMaker() public {
+        Order memory order = _createOrder(address(contractWallet), yes, 50_000_000, 100_000_000, Side.BUY);
+        order.signatureType = SignatureType.POLY_1271;
+        // signer == carla, maker == contractWallet
+        order.signer = carla;
+        bytes32 orderHash = exchange.hashOrder(order);
+        order.signature = _signMessage(carlaPK, orderHash);
+        vm.expectRevert(InvalidSignature.selector);
+        exchange.validateOrderSignature(orderHash, order);
+    }
 }

--- a/src/exchange/test/ERC1271Signature.t.sol
+++ b/src/exchange/test/ERC1271Signature.t.sol
@@ -5,7 +5,6 @@ import { BaseExchangeTest } from "exchange/test/BaseExchangeTest.sol";
 import { Order, Side, SignatureType } from "exchange/libraries/OrderStructs.sol";
 
 contract ERC1271SignatureTest is BaseExchangeTest {
-
     function test_validate1271Signature() public {
         Order memory order =
             _createAndSign1271Order(carlaPK, address(contractWallet), yes, 50_000_000, 100_000_000, Side.BUY);

--- a/src/exchange/test/MatchOrders.t.sol
+++ b/src/exchange/test/MatchOrders.t.sol
@@ -3,7 +3,7 @@ pragma solidity <0.9.0;
 
 import { BaseExchangeTest } from "exchange/test/BaseExchangeTest.sol";
 
-import { Order, Side, MatchType, OrderStatus } from "exchange/libraries/OrderStructs.sol";
+import { Order, Side } from "exchange/libraries/OrderStructs.sol";
 
 contract MatchOrdersTest is BaseExchangeTest {
     function setUp() public override {

--- a/src/exchange/test/Signatures.t.sol
+++ b/src/exchange/test/Signatures.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity <0.9.0;
+
+import { ERC1271Mock } from "dev/mocks/ERC1271Mock.sol";
+
+import { BaseExchangeTest } from "exchange/test/BaseExchangeTest.sol";
+import { Order, Side, SignatureType } from "exchange/libraries/OrderStructs.sol";
+
+contract SignaturesTest is BaseExchangeTest {
+
+    function test_validateOrderSignature() public {
+        Order memory order = _createAndSignOrder(bobPK, yes, 50_000_000, 100_000_000, Side.BUY);
+        exchange.validateOrderSignature(exchange.hashOrder(order), order);
+    }
+
+    function test_validate1271Signature() public {
+        Order memory order =
+            _createAndSign1271Order(carlaPK, address(contractWallet), yes, 50_000_000, 100_000_000, Side.BUY);
+        exchange.validateOrderSignature(exchange.hashOrder(order), order);
+    }
+
+    function test_validate1271Signature_revert_incorrectSigner() public {
+        Order memory order = _createOrder(address(contractWallet), yes, 50_000_000, 100_000_000, Side.BUY);
+        order.signatureType = SignatureType.POLY_1271;
+        bytes32 orderHash = exchange.hashOrder(order);
+        order.signature = _signMessage(bobPK, orderHash);
+        vm.expectRevert(InvalidSignature.selector);
+        exchange.validateOrderSignature(orderHash, order);
+    }
+
+    function test_validate1271Signature_revert_sigType() public {
+        Order memory order = _createOrder(address(contractWallet), yes, 50_000_000, 100_000_000, Side.BUY);
+        order.signatureType = SignatureType.EOA;
+        bytes32 orderHash = exchange.hashOrder(order);
+        order.signature = _signMessage(carlaPK, orderHash);
+        vm.expectRevert(InvalidSignature.selector);
+        exchange.validateOrderSignature(orderHash, order);
+    }
+
+    function test_validate1271Signature_revert_nonContract() public {
+        Order memory order = _createOrder(carla, yes, 50_000_000, 100_000_000, Side.BUY);
+        order.signatureType = SignatureType.POLY_1271;
+        bytes32 orderHash = exchange.hashOrder(order);
+        order.signature = _signMessage(carlaPK, orderHash);
+        vm.expectRevert(InvalidSignature.selector);
+        exchange.validateOrderSignature(orderHash, order);
+    }
+
+    function test_validate1271Signature_revert_invalidContract() public {
+        // revert when using a non 1271 contract
+        Order memory order = _createOrder(address(usdc), yes, 50_000_000, 100_000_000, Side.BUY);
+        order.signatureType = SignatureType.POLY_1271;
+        bytes32 orderHash = exchange.hashOrder(order);
+        order.signature = _signMessage(carlaPK, orderHash);
+        vm.expectRevert(InvalidSignature.selector);
+        exchange.validateOrderSignature(orderHash, order);
+    }
+}


### PR DESCRIPTION
* Enable 1271 signatures on the CTF Exchange

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables ERC1271 contract-wallet signatures for orders using solady’s SignatureChecker, with supporting mocks/tests and config updates.
> 
> - **Exchange / Signatures**:
>   - Add `POLY_1271` to `SignatureType` and implement `verifyPoly1271Signature` using `SignatureCheckerLib.isValidSignatureNow` in `Signatures.sol`.
>   - Integrate 1271 path into `isValidSignature`; minor doc updates.
> - **Types**:
>   - Extend `SignatureType` enum; minor enum formatting in `OrderStructs.sol`.
> - **Tests**:
>   - New `ERC1271Mock` contract for signing.
>   - Add `ERC1271Signature.t.sol` covering valid and revert cases (wrong signer, non-contract, wrong type, invalid contract, signer/maker mismatch).
>   - Update `BaseExchangeTest` with 1271 wallet setup and `_createAndSign1271Order`; adjust imports in tests.
> - **Dependencies / Config**:
>   - Add `lib/solady` submodule and remapping; lock in `foundry.lock`.
>   - Format tweak in `foundry.toml` (`wrap_comments = true`).
>   - CI: rename workflow to `Tests` and minor cleanup in `.github/workflows/Tests.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e5dacb6f6fac81896cded692a1b24723cd1f28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->