### PR TITLE
[DOC] Fix wrong variable name

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -125,7 +125,7 @@ The `CTFExchange` contract facilitates atomic swaps between binary outcome token
 {
   "maker": "userB",
   "makerAsset": "A'",
-  "takerAsset": "C'",
+  "takerAsset": "C",
   "makerAmount": 100,
   "takerAmount": 50
 }


### PR DESCRIPTION
line 128 mentioned a variable name `C'` which was not defined. This is most likely a typo for `C`, but it was making the key part of the explanation confusing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that corrects an example variable name; no runtime or contract logic is affected.
> 
> **Overview**
> Fixes a typo in `docs/Overview.md` where the Scenario 3 (`MERGE`) taker order pseudo-JSON incorrectly referenced an undefined collateral asset `C'`; it now correctly uses `C`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3bb5b40669561c087a2ffb6974d002d09f13196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->