### PR TITLE
Fix typo in takerAsset value in Overview.md

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -82,7 +82,7 @@ The `CTFExchange` contract facilitates atomic swaps between binary outcome token
 {
   "maker": "userB",
   "makerAsset": "C",
-  "takerAsset": "A''",
+  "takerAsset": "A'",
   "makerAmount": 25,
   "takerAmount": 50
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change correcting an example value; no runtime or contract logic is affected.
> 
> **Overview**
> Fixes a typo in `docs/Overview.md` where the Scenario 2 (MINT) taker order example incorrectly listed `takerAsset` as `A''`; it now correctly uses `A'` to match the narrative and asset definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbb600aef1d484f92d27bb952adae63d1c1e440c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->