### PR TITLE
docs: add archive notice and link to V2 deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+> This repository has been archived and is no longer maintained.
+>
+> Contract addresses have been updated. Please refer to the V2 repository for the latest deployments and integration details:
+> https://github.com/Polymarket/ctf-exchange-v2
+
 # Polymarket CTF Exchange
 
 [![Version][version-badge]][version-link]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior. Main risk is minor confusion if the V2 link or guidance is incorrect/outdated.
> 
> **Overview**
> Adds a prominent `WARNING` banner at the top of `README.md` stating the repository is archived/unmaintained and directing users to `ctf-exchange-v2` for updated contract addresses, deployments, and integration details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c98e2a2ad9ebaef31b1361c2f4fd2d85fc33ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->